### PR TITLE
fixed deprecated warning

### DIFF
--- a/encryption.js
+++ b/encryption.js
@@ -1,4 +1,3 @@
-
 var crypto = require('crypto');
 var algorithm = "bf-ecb";
 
@@ -12,20 +11,20 @@ function pad(text) {
 function Encryption() {
   self = this;
   self.encrypt = function(data, key) {
-    var cipher = crypto.createCipheriv(algorithm, Buffer(key), '');
+    var cipher = crypto.createCipheriv(algorithm, new Buffer(key), '');
     cipher.setAutoPadding(false);
     try {
-      return Buffer(cipher.update(pad(data), 'utf8', 'binary') + cipher.final('binary'), 'binary').toString('base64');
+      return new Buffer(cipher.update(pad(data), 'utf8', 'binary') + cipher.final('binary'), 'binary').toString('base64');
     } catch (e) {
       return null;
     }
   }
 
   self.decrypt = function(data, key) {
-    var decipher = crypto.createDecipheriv(algorithm, Buffer(key), '');
+    var decipher = crypto.createDecipheriv(algorithm, new Buffer(key), '');
     decipher.setAutoPadding(false);
     try {
-      return (decipher.update(Buffer(data, 'base64').toString('binary'), 'binary', 'utf8')+ decipher.final('utf8')).replace(/\x00+$/g, '');
+      return (decipher.update(new Buffer(data, 'base64').toString('binary'), 'binary', 'utf8')+ decipher.final('utf8')).replace(/\x00+$/g, '');
     } catch (e) {
       return null;
     }


### PR DESCRIPTION
```
DeprecationWarning: Using Buffer without `new` will soon stop working. Use `new Buffer()`, or preferably `Buffer.from()`, `Buffer.allocUnsafe()` or `Buffer.alloc()` instead.
```